### PR TITLE
[smf] Update manifests to reflect self assembling switch zone

### DIFF
--- a/lldpd/misc/lldpd.xml
+++ b/lldpd/misc/lldpd.xml
@@ -4,11 +4,15 @@
 <service_bundle type='manifest' name='oxide-lldpd'>
 
     <service name='oxide/lldpd' type='service' version='1'>
-    <create_default_instance enabled='false'/>
+    <create_default_instance enabled='true'/>
     <single_instance/>
 
     <dependency name='net-physical' grouping='require_all' restart_on='none' type='service'>
       <service_fmri value='svc:/network/physical'/>
+    </dependency>
+
+    <dependency name='zone_network_setup' grouping='require_all' restart_on='none' type='service'>
+      <service_fmri value='svc:/oxide/zone-network-setup:default' />
     </dependency>
 
     <exec_method name='start'


### PR DESCRIPTION
**DO NOT MERGE** - let's wait until release 8 is out the door

In Omicron, we are converting all zones to be self assembling. This means we are no longer having to boot the zone, configure zone networking, configure all the services and finally refresh each service.

For the switch zone we have two new services that configure common zone networking in https://github.com/oxidecomputer/omicron/pull/5593. This PR adds these dependencies to the SMF files that require them, and sets the service default instance as enabled by default.

This PR should be merged in conjunction with https://github.com/oxidecomputer/omicron/pull/5593