### PR TITLE
Add support for "address type 6"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ dependencies = [
  "common 0.1.0",
  "futures",
  "progenitor",
+ "protocol",
  "reqwest",
  "schemars",
  "serde",

--- a/lldpd-client/Cargo.toml
+++ b/lldpd-client/Cargo.toml
@@ -8,6 +8,7 @@ description = "Client library for the Oxide LLDP daemon"
 chrono.workspace = true
 common.workspace = true
 futures.workspace = true
+protocol.workspace = true
 progenitor.workspace = true
 reqwest.workspace = true
 schemars.workspace = true

--- a/lldpd-client/src/lib.rs
+++ b/lldpd-client/src/lib.rs
@@ -29,6 +29,10 @@ progenitor::generate_api!(
         slog::trace!(log, "client response"; "result" => ?result);
     }),
     derives = [PartialEq],
+ replace = {
+        ManagementAddress = protocol::types::ManagementAddress,
+        NetworkAddress = protocol::types::NetworkAddress,
+    }
 );
 
 impl fmt::Display for types::MacAddr {

--- a/lldpd/src/interfaces.rs
+++ b/lldpd/src/interfaces.rs
@@ -237,7 +237,7 @@ pub fn build_lldpdu(
         .unwrap_or(&switchinfo.management_addrs)
         .iter()
         .map(|addr| protocol::types::ManagementAddress {
-            addr: *addr,
+            addr: (*addr).into(),
             // TODO-completeness: include an interface number with each
             // management address.
             interface_num: protocol::types::InterfaceNum::Unknown(0),

--- a/openapi/lldpd.json
+++ b/openapi/lldpd.json
@@ -1187,8 +1187,7 @@
             "type": "object",
             "properties": {
               "NetworkAddress": {
-                "type": "string",
-                "format": "ip"
+                "$ref": "#/components/schemas/NetworkAddress"
               }
             },
             "required": [
@@ -1368,8 +1367,7 @@
         "type": "object",
         "properties": {
           "addr": {
-            "type": "string",
-            "format": "ip"
+            "$ref": "#/components/schemas/NetworkAddress"
           },
           "interface_num": {
             "$ref": "#/components/schemas/InterfaceNum"
@@ -1451,6 +1449,40 @@
           "items"
         ]
       },
+      "NetworkAddress": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "IpAddr": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "IpAddr"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "IEEE802": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0
+                }
+              }
+            },
+            "required": [
+              "IEEE802"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
       "PortId": {
         "oneOf": [
           {
@@ -1493,8 +1525,7 @@
             "type": "object",
             "properties": {
               "NetworkAddress": {
-                "type": "string",
-                "format": "ip"
+                "$ref": "#/components/schemas/NetworkAddress"
               }
             },
             "required": [

--- a/protocol/src/types.rs
+++ b/protocol/src/types.rs
@@ -229,6 +229,13 @@ fn hex2str(data: &[u8]) -> String {
     }
 }
 
+// IANA Address Family Numbers for the address types we currently support as
+// seen in:
+// https://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml
+const IANA_IPV4: u8 = 1;
+const IANA_IPV6: u8 = 2;
+const IANA_802: u8 = 6;
+
 #[derive(
     Clone,
     Debug,
@@ -242,7 +249,11 @@ fn hex2str(data: &[u8]) -> String {
     Serialize,
 )]
 pub enum NetworkAddress {
+    //  IPv4 or IPv6
     IpAddr(IpAddr),
+    // 802 (includes all 802 media plus Ethernet "canonical format")".
+    // This suggests that we need to be prepared for any 802 address, not just
+    // MAC addresses.
     IEEE802(Vec<u8>),
 }
 
@@ -310,10 +321,6 @@ impl fmt::Display for ChassisId {
         }
     }
 }
-
-const IANA_IPV4: u8 = 1;
-const IANA_IPV6: u8 = 2;
-const IANA_802: u8 = 6;
 
 // An address is represented as a string of octets, where the first two contain
 // the IANA registered number for the address type, and the remaining octects


### PR DESCRIPTION
```
root@oxz_switch1:~# ./overwatch snoop tfportqsfp15_0 --eth-type lldp
=====|
Eth  | 44:F4:77:B1:07:33 > 01:80:C2:00:00:0E et Lldp len 360
Lldp | ChassisID Mac Address - 44:f4:77:b1:07:00
     | PortId Locally assigned - 613
     | TTL 120
     | PortDescription et-0/0/48
     | System Name asilomar-juniper
     | System Description Juniper Networks, Inc. qfx5100-48t-6q Ethernet Switch, kernel JUNOS 21.4R3-S4.13, Build date: 2023-07-09 13:47:23 UTC Copyright (c) 1996-2023 Juniper Networks, Inc.
     | Management addresses:
     |     IEEE802(44:f4:77:b1:08:38) IfIndex (17) (OID: 0c:01:03:06:01:02:01:1f:01:01:01:01:11)    <-- here --
```