### PR TITLE
don't write out ffi.rs to src dir

### DIFF
--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -20,9 +20,5 @@ do
 	cargo clippy --features $feat -- --deny warnings
 done
 
-# This file is generated dynamically during the build, and its absence here
-# makes rustfmt sad.
-echo '#![rustfmt::skip]' > lldpd/src/ffi.rs
-
 banner "fmt"
 cargo fmt -- --check

--- a/lldpd/build.rs
+++ b/lldpd/build.rs
@@ -6,6 +6,8 @@
 
 #[cfg(target_os = "linux")]
 fn gen_bindings() -> std::io::Result<()> {
+    use std::path::PathBuf;
+
     let functions = vec![
         "pcap_open_offline",
         "pcap_create",
@@ -30,9 +32,10 @@ fn gen_bindings() -> std::io::Result<()> {
         b = b.allowlist_function(f);
     }
 
-    b = b.raw_line("#![allow(nonstandard_style)]");
-    b = b.raw_line("#![allow(dead_code)]");
-    b.generate().unwrap().write_to_file("./src/ffi.rs")
+    let mut out_path =
+        PathBuf::from(std::env::var("OUT_DIR").expect("Cargo sets OUT_DIR"));
+    out_path.push("ffi.rs");
+    b.generate().unwrap().write_to_file(&out_path)
 }
 
 fn main() -> anyhow::Result<()> {

--- a/lldpd/src/main.rs
+++ b/lldpd/src/main.rs
@@ -32,7 +32,12 @@ mod dendrite;
 mod smf;
 
 #[cfg(target_os = "linux")]
-mod ffi;
+mod ffi {
+    #![allow(nonstandard_style)]
+    #![allow(dead_code)]
+
+    include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
+}
 #[cfg(target_os = "illumos")]
 mod plat_illumos;
 #[cfg(target_os = "linux")]

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -17,9 +17,4 @@ banner Build Omicron
 ptime -m cargo build --release --features "smf,dendrite"
 
 banner "fmt"
-if [ ! -x lldpd/src/ffi.rs ]; then
-	# This file is generated dynamically during the linux build, and its
-	# absence here makes rustfmt sad.
-	echo '#![rustfmt::skip]' > lldpd/src/ffi.rs
-fi
 cargo fmt -- --check


### PR DESCRIPTION
This file shows up as untracked, and therefore gets auto-added by systems like Jujutsu. It could be added to `.gitignore`, but the easier (and recommended) thing to do is to write this file out to the Cargo-defined `OUT_DIR`.

Ctrl-clicking to `ffi.rs` in rust-analyzer continues to work as usual.
