### PR TITLE
[1/2] [xtask] migrate to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,8 +5116,8 @@ dependencies = [
  "anyhow",
  "camino",
  "chrono",
+ "clap 4.5.45",
  "omicron-zone-package",
- "structopt",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dpd-client = { git = "https://github.com/oxidecomputer/dendrite", branch = "main
 anyhow = "1.0"
 camino = { version = "1.1", features = ["serde1"] }
 chrono = "0.4"
+clap = { version = "4.5.45", features = ["derive"] }
 dropshot = "0.16.3"
 futures = "0.3"
 http = "0.2.9"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 anyhow.workspace = true
 camino.workspace = true
 chrono.workspace = true
+clap.workspace = true
 omicron-zone-package.workspace = true
-structopt.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
I'm going to add an xtask to manage OpenAPI documents soon, and the template I currently have works with clap.

Also replace the manual `FromStr` with `ValueEnum`.
