### PR TITLE
Stub out macOS functionality for LLDPD

### DIFF
--- a/lldpd/src/interfaces.rs
+++ b/lldpd/src/interfaces.rs
@@ -39,6 +39,8 @@ use protocol::types::Lldpdu;
 use crate::plat_illumos as plat;
 #[cfg(target_os = "linux")]
 use crate::plat_linux as plat;
+#[cfg(target_os = "macos")]
+use crate::plat_macos as plat;
 
 // How many times do we attempt to shutdown an interface before returning an
 // error to the client?  In practice this should never happen, but setting a

--- a/lldpd/src/interfaces.rs
+++ b/lldpd/src/interfaces.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;

--- a/lldpd/src/main.rs
+++ b/lldpd/src/main.rs
@@ -45,6 +45,8 @@ mod ffi {
 mod plat_illumos;
 #[cfg(target_os = "linux")]
 mod plat_linux;
+#[cfg(target_os = "macos")]
+mod plat_macos;
 
 /// All global state for the lldpd daemon
 pub struct Global {

--- a/lldpd/src/plat_macos.rs
+++ b/lldpd/src/plat_macos.rs
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2026 Oxide Computer Company
+
+// macOS platform stubs for lldpd.  Packet capture and injection are not
+// implemented; the Transport is a no-op that never delivers or sends frames.
+// MAC address discovery uses `ifconfig`.
+
+use std::sync::Arc;
+
+use tokio::process::Command;
+use tokio::sync::Notify;
+
+use crate::types::LldpdResult;
+use crate::Global;
+use crate::LldpdError;
+use protocol::macaddr::MacAddr;
+
+/// Stub transport for macOS.  It never produces incoming packets (readable()
+/// returns a future that is always pending) and silently discards outgoing
+/// packets.
+pub struct Transport {
+    _iface: String,
+    /// Never notified; keeps readable() pending indefinitely so the rest of
+    /// the event loop (timers, control messages) continues to work.
+    _notify: Arc<Notify>,
+}
+
+impl Transport {
+    pub fn new(iface: &str) -> LldpdResult<Transport> {
+        Ok(Transport {
+            _iface: iface.to_string(),
+            _notify: Arc::new(Notify::new()),
+        })
+    }
+
+    /// Returns a future that is always pending (stub – packet capture is not
+    /// implemented on macOS).
+    pub async fn readable(&self) -> LldpdResult<()> {
+        self._notify.notified().await;
+        Ok(())
+    }
+
+    /// No-op on macOS (packet injection is not implemented).
+    pub fn packet_send(&self, _data: &[u8]) -> LldpdResult<()> {
+        Ok(())
+    }
+
+    /// Always returns `Ok(None)` on macOS (packet capture is not implemented).
+    pub fn packet_recv(&self, _buf: &mut [u8]) -> LldpdResult<Option<usize>> {
+        Ok(None)
+    }
+}
+
+/// Look up the MAC address of `name` by parsing `ifconfig <name>` output.
+pub async fn get_iface_and_mac(
+    _g: &Global,
+    name: &str,
+) -> LldpdResult<(String, MacAddr)> {
+    let out = Command::new("ifconfig").arg(name).output().await?;
+    if !out.status.success() {
+        return Err(LldpdError::Other(format!(
+            "ifconfig {name} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for line in stdout.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("ether ") {
+            let mac_str = rest.split_whitespace().next().unwrap_or("").trim();
+            let mac = mac_str.parse().map_err(|e| {
+                LldpdError::Other(format!(
+                    "failed to parse MAC address '{mac_str}': {e:?}"
+                ))
+            })?;
+            return Ok((name.to_string(), mac));
+        }
+    }
+
+    Err(LldpdError::Other(format!(
+        "could not find MAC address for interface {name}"
+    )))
+}

--- a/xtask/src/macos.rs
+++ b/xtask/src/macos.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2026 Oxide Computer Company
+
+// macOS xtask stub – packaging is not implemented for macOS.
+
+use anyhow::anyhow;
+
+use crate::DistFormat;
+
+pub async fn dist(_release: bool, _format: DistFormat) -> anyhow::Result<()> {
+    Err(anyhow!("dist is not implemented on macOS"))
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 #[cfg(any(target_os = "illumos", target_os = "linux"))]
 use std::fs;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,11 +4,14 @@
 
 // Copyright 2024 Oxide Computer Company
 
+#[cfg(any(target_os = "illumos", target_os = "linux"))]
 use std::fs;
 #[cfg(target_os = "illumos")]
 use std::io::Read;
+#[cfg(any(target_os = "illumos", target_os = "linux"))]
 use std::path::Path;
 
+#[cfg(any(target_os = "illumos", target_os = "linux"))]
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, ValueEnum};
 
@@ -23,6 +26,11 @@ use illumos as plat;
 mod linux;
 #[cfg(target_os = "linux")]
 use linux as plat;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+use macos as plat;
 
 // Possible formats for a bundled dendrite distro.  Currently the two "zone"
 // package formats are helios-only.
@@ -57,6 +65,7 @@ enum Xtasks {
     },
 }
 
+#[cfg(any(target_os = "illumos", target_os = "linux"))]
 fn collect<T: ToString>(src: &str, dst: &str, files: Vec<T>) -> Result<()> {
     let src_dir = Path::new(src);
     if !src_dir.is_dir() {
@@ -84,6 +93,7 @@ fn collect<T: ToString>(src: &str, dst: &str, files: Vec<T>) -> Result<()> {
     Ok(())
 }
 
+#[cfg(any(target_os = "illumos", target_os = "linux"))]
 fn collect_binaries(release: bool, dst: &str) -> Result<()> {
     let src = match release {
         true => "./target/release",


### PR DESCRIPTION
In order to include LLDPD in omicron's test suite, we need to have a working build for macOS. This build does not need to be fully functional, just a stub that starts up and runs is fine. This should help us get past the CI errors we're seeing in the branch that adds LLDPD as a test dependency.